### PR TITLE
Fix a minor typo in carmine readme

### DIFF
--- a/carmine/README.md
+++ b/carmine/README.md
@@ -26,7 +26,7 @@ Add this to a file named `reflect-config.json` and add it to your GraalVM config
 [
   {
     "name":"org.apache.commons.pool2.impl.DefaultEvictionPolicy",
-    "allPublicConstructors" : true,
+    "allPublicConstructors" : true
   }
 ]
 ```


### PR DESCRIPTION
There was a trailing comma in the sample `reflect-config.json` file for Carmine.