### PR TITLE
add pedestal to the list of libraries supported by graalvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Here the list of libraries tested:
 | :white_check_mark: | [system](./system)                                   | Layer on top of components                                          |                                |
 | :white_check_mark: | [tech.ml.dataset](./tech.ml.dataset)                 | A Clojure high performance data processing system                   |                                |
 | :white_check_mark: | [timbre](./timbre)                                   | Pure Clojure/Script logging library                                 |                                |
+| :white_check_mark: | [pedestal](./pedestal)                               | Pedestal is a sturdy and reliable base for services and APIs.       |                                |
 
 
 More libraries to come (*PRs are welcome*).

--- a/pedestal/.gitignore
+++ b/pedestal/.gitignore
@@ -1,0 +1,12 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/pedestal/README.md
+++ b/pedestal/README.md
@@ -1,0 +1,18 @@
+# pedestal
+
+Testing whether [pedestal](https://github.com/pedestal/pedestal) library can be used in a native binary image with GraalVM.
+
+## Usage
+
+Currently testing:
+
+    [io.pedestal/pedestal.service "0.5.10"]
+
+Test with:
+
+    lein do run, clean, uberjar, native, run-native
+
+## Results
+
+`[io.pedestal.http :as http]` :white_check_mark:
+`[io.pedestal.jetty :as jetty]` :white_check_mark:

--- a/pedestal/project.clj
+++ b/pedestal/project.clj
@@ -1,0 +1,28 @@
+(defproject pedestal "0.1.0-SNAPSHOT"
+
+  :paths ["src"]
+  :dependencies [[org.clojure/clojure "1.10.2"]
+                 [io.pedestal/pedestal.service "0.5.10"]
+                 [io.pedestal/pedestal.jetty "0.5.10"]]
+
+  :main simple.main
+
+  :uberjar-name "simple-main.jar"
+
+  :profiles {:uberjar {:aot :all}
+             :dev {:plugins [[lein-shell "0.5.0"]]}}
+
+  :aliases
+  {"native"
+   ["shell"
+    "native-image"
+    "--report-unsupported-elements-at-runtime"
+    "--no-server"
+    "--allow-incomplete-classpath"
+    "--initialize-at-build-time"
+    "--enable-url-protocols=http,https"
+    "-Dio.pedestal.log.defaultMetricsRecorder=nil"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-H:Name=./target/${:name}"]
+
+   "run-native" ["shell" "./target/${:name}"]})

--- a/pedestal/src/simple/main.clj
+++ b/pedestal/src/simple/main.clj
@@ -1,0 +1,25 @@
+(ns simple.main
+  (:require [io.pedestal.http :as http])
+  (:gen-class))
+
+(defn handler
+  [_]
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body "Hello GraalVM"})
+
+(def routes
+  #{["/" :get handler :route-name :hello]})
+
+(defn -main
+  "I don't do a whole lot ... yet."
+  [& args]
+  (println "server started on: http://localhost:3000/")
+  (-> {:env          :dev
+       ::http/type   :jetty
+       ::http/port   3000
+       ::http/join?  false
+       ::http/routes routes}
+      http/create-server
+      http/start))
+


### PR DESCRIPTION
I do `moclojer` distribution via binary (native-image)
ref: https://github.com/avelino/moclojer/issues/4