### PR TITLE
Adding more use cases, bump Pedestal(0.7.2)  and Clojure(1.12.0) to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,53 +12,53 @@ Here the instructions on how to build your own Clojure projects with GraalVM.
 
 Here the list of libraries tested:
 
-| Status              | Library                                              | Description                                                         | Remarks                        |
-|:-------------------:|------------------------------------------------------|---------------------------------------------------------------------|--------------------------------|
-| :white_check_mark:  | [Clojure core](./clojure)                            | Clojure core                                                        |                                |
-| :white_check_mark:  | [clojure spec](./spec)                               | Clojure Spec                                                        |                                |
-| :white_check_mark:  | [clojure/tools.logging](./tools-logging)             | Logging library                                                     |                                |
-| :white_check_mark:  | [clojure/tools.logging+log4j](./tools-logging-log4j) | Logging library                                                     |                                |
-| :white_check_mark:  | [aleph](./aleph)                                     | Web server                                                          |                                |
-| :white_check_mark:  | [amazonica+s3](./amazonica-s3)                       | Cloud API wrapper library                                           |                                |
-| :white_check_mark:  | [asami](./asami)                                     | Asami DB                                                            |                                |
-| :white_check_mark:  | [aws-api+s3](./aws-api-s3)                           | Cognitect AWS client library                                        |                                |
-| :white_check_mark:  | [buffy](./buffy)                                     | Buffy, The Byte Buffer Slayer                                       |                                |
-| :white_check_mark:  | [carmine](./carmine)                                 | Redis client and message queue for Clojure                          |                                |
-| :white_check_mark:  | [cheshire](./cheshire)                               | JSON parser/writer                                                  |                                |
-| :white_check_mark:  | [cli4clj](./cli4clj)                                 | Interactive Command Line Interfaces (CLIs) for Clojure Applications |                                |
-| :white_check_mark:  | [cljfmt](./cljfmt)                                   | Source Formatter                                                    |                                |
-| :white_check_mark:  | [clj-http-lite](./clj-http-lite)                     | Web client                                                          |                                |
-| :x:                 | [clj-sophia](./clj-sophia)                           | A fast RAM-Disk hybrid storage                                      | *Runtime error/JNA*            |
-| :white_check_mark:  | [clj-uuid](./clj-uuid)                               | RFC4122 Unique Identifiers for Clojure                              | No objects in namespaced uuids |
-| :white_check_mark:  | [clara-rules](./clara-rules)                         | A Clojure forward-chaining rules engine                             | *Using AOT compiled session*   |
-| :white_check_mark:  | [clostache](./clostache)                             | {{ mustache }} for Clojure                                          |                                |
-| :white_check_mark:  | [component](./component)                             | Managing lifecycle and dependencies of software                     |                                |
-| :white_check_mark:  | [cprop](./cprop)                                     | Configuration/property management                                   |                                |
-| :white_check_mark:  | [datascript](./datascript)                           | Immutable database and Datalog query engine                         |                                |
-| :warning:           | [fastmath](./fastmath)                               | Fast and primitive math and stats library                           | *See README*                   |
-| :white_check_mark:  | [fire](./fire)                                       | A lightweight clojure client for Firebase based using the REST API. |                                |
-| :white_check_mark:  | [hiccup](./hiccup)                                   | Fast library for rendering HTML in Clojure                          |                                |
-| :white_check_mark:  | [http-kit](./http-kit)                               | Web server and server                                               |                                |
-| :white_check_mark:  | [integrant](./integrant)                             | Alternative to mount, component etc.                                |                                |
-| :white_check_mark:  | [lacinia](./lacinia)                                 | A GraphQL server implementation in pure Clojure                     |                                |
-| :white_check_mark:  | [loom](./loom)                                       | A Graph manipulation and computation library.                       |                                |
-| :x:                 | [monger](./monger)                                   | An idiomatic Clojure MongoDB driver with sane defaults              |                                |
-| :white_check_mark:  | [μ/log](./mulog)                                     | Event logging system                                                |                                |
-| :white_check_mark:  | [next.jdbc + honeysql](./next-jdbc)                  | Database driver and SQL-in-Clojure                                  |                                |
-| :white_check_mark:  | [nippy](./nippy)                                     | Clojure serialization/deserialization library                       |                                |
-| :white_check_mark:  | [pp-grid](./pp-grid)                                 | A text-formatting library                                           |                                |
-| :white_check_mark:  | [ring/jetty](./ring-jetty)                           | Web server                                                          |                                |
-| :white_check_mark:  | [RoaringBitmap](./roaring)                           | Bitset library                                                      |                                |
-| :white_check_mark:  | [safely](./safely)                                   | Circuit breaker                                                     |                                |
-| :white_check_mark:  | [secure-random](./secure-random)                     | `SecureRandom` initialization                                       |                                |
-| :white_check_mark:  | [selmer](./selmer)                                   | A fast, Django inspired template system for Clojure.                |                                |
-| :white_check_mark:  | [system](./system)                                   | Layer on top of components                                          |                                |
-| :white_check_mark:  | [tech.ml.dataset](./tech.ml.dataset)                 | A Clojure high performance data processing system                   |                                |
-| :white_check_mark:  | [timbre](./timbre)                                   | Pure Clojure/Script logging library                                 |                                |
-| :white_check_mark:  | [pedestal](./pedestal)                               | Pedestal is a sturdy and reliable base for services and APIs.       |                                |
-| :white_check_mark:  | [claypoole](./claypoole)                             | Claypoole: Threadpool tools for Clojure                             |                                |
-| :white_check_mark:  | [upit](./upit)                                       | Very very simple library to initialise your app stack.              |                                |
-| ::white_check_mark: | [zetasketch](./zetasketch)                           | Sketch data structures like HLL                                     | requires reflect-config.json   |
+|       Status       | Library                                              | Description                                                         | Remarks                        |
+|:------------------:|------------------------------------------------------|---------------------------------------------------------------------|--------------------------------|
+| :white_check_mark: | [Clojure core](./clojure)                            | Clojure core                                                        |                                |
+| :white_check_mark: | [clojure spec](./spec)                               | Clojure Spec                                                        |                                |
+| :white_check_mark: | [clojure/tools.logging](./tools-logging)             | Logging library                                                     |                                |
+| :white_check_mark: | [clojure/tools.logging+log4j](./tools-logging-log4j) | Logging library                                                     |                                |
+| :white_check_mark: | [aleph](./aleph)                                     | Web server                                                          |                                |
+| :white_check_mark: | [amazonica+s3](./amazonica-s3)                       | Cloud API wrapper library                                           |                                |
+| :white_check_mark: | [asami](./asami)                                     | Asami DB                                                            |                                |
+| :white_check_mark: | [aws-api+s3](./aws-api-s3)                           | Cognitect AWS client library                                        |                                |
+| :white_check_mark: | [buffy](./buffy)                                     | Buffy, The Byte Buffer Slayer                                       |                                |
+| :white_check_mark: | [carmine](./carmine)                                 | Redis client and message queue for Clojure                          |                                |
+| :white_check_mark: | [cheshire](./cheshire)                               | JSON parser/writer                                                  |                                |
+| :white_check_mark: | [cli4clj](./cli4clj)                                 | Interactive Command Line Interfaces (CLIs) for Clojure Applications |                                |
+| :white_check_mark: | [cljfmt](./cljfmt)                                   | Source Formatter                                                    |                                |
+| :white_check_mark: | [clj-http-lite](./clj-http-lite)                     | Web client                                                          |                                |
+|        :x:         | [clj-sophia](./clj-sophia)                           | A fast RAM-Disk hybrid storage                                      | *Runtime error/JNA*            |
+| :white_check_mark: | [clj-uuid](./clj-uuid)                               | RFC4122 Unique Identifiers for Clojure                              | No objects in namespaced uuids |
+| :white_check_mark: | [clara-rules](./clara-rules)                         | A Clojure forward-chaining rules engine                             | *Using AOT compiled session*   |
+| :white_check_mark: | [clostache](./clostache)                             | {{ mustache }} for Clojure                                          |                                |
+| :white_check_mark: | [component](./component)                             | Managing lifecycle and dependencies of software                     |                                |
+| :white_check_mark: | [cprop](./cprop)                                     | Configuration/property management                                   |                                |
+| :white_check_mark: | [datascript](./datascript)                           | Immutable database and Datalog query engine                         |                                |
+|     :warning:      | [fastmath](./fastmath)                               | Fast and primitive math and stats library                           | *See README*                   |
+| :white_check_mark: | [fire](./fire)                                       | A lightweight clojure client for Firebase based using the REST API. |                                |
+| :white_check_mark: | [hiccup](./hiccup)                                   | Fast library for rendering HTML in Clojure                          |                                |
+| :white_check_mark: | [http-kit](./http-kit)                               | Web server and server                                               |                                |
+| :white_check_mark: | [integrant](./integrant)                             | Alternative to mount, component etc.                                |                                |
+| :white_check_mark: | [lacinia](./lacinia)                                 | A GraphQL server implementation in pure Clojure                     |                                |
+| :white_check_mark: | [loom](./loom)                                       | A Graph manipulation and computation library.                       |                                |
+|        :x:         | [monger](./monger)                                   | An idiomatic Clojure MongoDB driver with sane defaults              |                                |
+| :white_check_mark: | [μ/log](./mulog)                                     | Event logging system                                                |                                |
+| :white_check_mark: | [next.jdbc + honeysql](./next-jdbc)                  | Database driver and SQL-in-Clojure                                  |                                |
+| :white_check_mark: | [nippy](./nippy)                                     | Clojure serialization/deserialization library                       |                                |
+| :white_check_mark: | [pp-grid](./pp-grid)                                 | A text-formatting library                                           |                                |
+| :white_check_mark: | [ring/jetty](./ring-jetty)                           | Web server                                                          |                                |
+| :white_check_mark: | [RoaringBitmap](./roaring)                           | Bitset library                                                      |                                |
+| :white_check_mark: | [safely](./safely)                                   | Circuit breaker                                                     |                                |
+| :white_check_mark: | [secure-random](./secure-random)                     | `SecureRandom` initialization                                       |                                |
+| :white_check_mark: | [selmer](./selmer)                                   | A fast, Django inspired template system for Clojure.                |                                |
+| :white_check_mark: | [system](./system)                                   | Layer on top of components                                          |                                |
+| :white_check_mark: | [tech.ml.dataset](./tech.ml.dataset)                 | A Clojure high performance data processing system                   |                                |
+| :white_check_mark: | [timbre](./timbre)                                   | Pure Clojure/Script logging library                                 |                                |
+| :white_check_mark: | [pedestal](./pedestal)                               | Pedestal is a sturdy and reliable base for services and APIs.       | requires reflect-config.json   |
+| :white_check_mark: | [claypoole](./claypoole)                             | Claypoole: Threadpool tools for Clojure                             |                                |
+| :white_check_mark: | [upit](./upit)                                       | Very very simple library to initialise your app stack.              |                                |
+| :white_check_mark: | [zetasketch](./zetasketch)                           | Sketch data structures like HLL                                     | requires reflect-config.json   |
 
 
 More libraries to come (*PRs are welcome*).

--- a/pedestal/.gitignore
+++ b/pedestal/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/
+/pedestal.iml

--- a/pedestal/README.md
+++ b/pedestal/README.md
@@ -1,12 +1,15 @@
 # pedestal
 
-Testing whether [pedestal](https://github.com/pedestal/pedestal) library can be used in a native binary image with GraalVM.
+Testing whether [pedestal](https://github.com/pedestal/pedestal) library can be used in a native binary image with
+GraalVM(23).
 
 ## Usage
 
 Currently testing:
 
-    [io.pedestal/pedestal.service "0.5.10"]
+    [org.clojure/clojure "1.12.0"]
+    [io.pedestal/pedestal.service "0.7.2"]
+    [io.pedestal/pedestal.jetty "0.7.2"]
 
 Test with:
 
@@ -16,3 +19,5 @@ Test with:
 
 `[io.pedestal.http :as http]` :white_check_mark:
 `[io.pedestal.jetty :as jetty]` :white_check_mark:
+`[io.pedestal.http.body-params :as body-params]` :white_check_mark:
+`[io.pedestal.interceptor :as pedestal.interceptor]` :white_check_mark:

--- a/pedestal/project.clj
+++ b/pedestal/project.clj
@@ -15,7 +15,7 @@
   :aliases
   {"native"
    ["shell"
-    "/Users/bruno.nascimento/Downloads/graalvm-jdk-23.0.1+11.1/Contents/Home/bin/native-image"
+    "native-image"
     "--no-fallback"
     "--report-unsupported-elements-at-runtime"
     "--no-server"

--- a/pedestal/project.clj
+++ b/pedestal/project.clj
@@ -1,9 +1,9 @@
 (defproject pedestal "0.1.0-SNAPSHOT"
 
   :paths ["src"]
-  :dependencies [[org.clojure/clojure "1.10.2"]
-                 [io.pedestal/pedestal.service "0.5.10"]
-                 [io.pedestal/pedestal.jetty "0.5.10"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [io.pedestal/pedestal.service "0.7.2"]
+                 [io.pedestal/pedestal.jetty "0.7.2"]]
 
   :main simple.main
 
@@ -15,7 +15,7 @@
   :aliases
   {"native"
    ["shell"
-    "native-image"
+    "/Users/bruno.nascimento/Downloads/graalvm-jdk-23.0.1+11.1/Contents/Home/bin/native-image"
     "--report-unsupported-elements-at-runtime"
     "--no-server"
     "--allow-incomplete-classpath"
@@ -23,6 +23,7 @@
     "--enable-url-protocols=http,https"
     "-Dio.pedestal.log.defaultMetricsRecorder=nil"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-H:ReflectionConfigurationFiles=reflect-config.json"
     "-H:Name=./target/${:name}"]
 
    "run-native" ["shell" "./target/${:name}"]})

--- a/pedestal/project.clj
+++ b/pedestal/project.clj
@@ -16,6 +16,7 @@
   {"native"
    ["shell"
     "/Users/bruno.nascimento/Downloads/graalvm-jdk-23.0.1+11.1/Contents/Home/bin/native-image"
+    "--no-fallback"
     "--report-unsupported-elements-at-runtime"
     "--no-server"
     "--allow-incomplete-classpath"

--- a/pedestal/reflect-config.json
+++ b/pedestal/reflect-config.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "org.eclipse.jetty.server.ServerConnector",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "org.eclipse.jetty.server.ConnectionFactory[]",
+    "unsafeAllocated": true
+  }
+]

--- a/pedestal/src/simple/main.clj
+++ b/pedestal/src/simple/main.clj
@@ -38,4 +38,3 @@
        ::http/routes routes}
       http/create-server
       http/start))
-

--- a/pedestal/src/simple/main.clj
+++ b/pedestal/src/simple/main.clj
@@ -1,18 +1,34 @@
 (ns simple.main
-  (:require [io.pedestal.http :as http])
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.interceptor :as pedestal.interceptor])
   (:gen-class))
 
+(def hello-word-interceptor
+  (pedestal.interceptor/interceptor
+    {:name  ::hello-world
+     :enter (fn [context]
+              (assoc-in context [:request :hello] :world))}))
+
 (defn handler
-  [_]
-  {:status 200
+  [{:keys [hello]}]
+  {:status  200
    :headers {"Content-Type" "text/html"}
-   :body "Hello GraalVM"})
+   :body    (str "Hello GraalVM " (name hello))})
+
+(defn echo-handler
+  [{:keys [json-params]}]
+  {:status 200
+   :body   json-params})
 
 (def routes
-  #{["/" :get handler :route-name :hello]})
+  #{["/" :get [hello-word-interceptor
+               handler] :route-name :hello]
+    ["/echo" :post [(body-params/body-params)
+                    http/json-body
+                    echo-handler] :route-name :hello-echo]})
 
 (defn -main
-  "I don't do a whole lot ... yet."
   [& args]
   (println "server started on: http://localhost:3000/")
   (-> {:env          :dev


### PR DESCRIPTION
* Introduced a new interceptor `hello-word-interceptor` and an `echo-handler` in `pedestal/src/simple/main.clj`, which adds a new route for handling POST requests with JSON body parameters.

* Added `pedestal/reflect-config.json` to support GraalVM native image generation by specifying reflection configurations for Jetty server classes.

* Bump Clojure to `1.12.0`.
* Bump Pedestal to `0.7.2`. 