### PR TITLE
Add `pg2-core` and add `graal-build-time` to Pedestal

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Here the list of libraries tested:
 | :white_check_mark: | [claypoole](./claypoole)                             | Claypoole: Threadpool tools for Clojure                             |                                |
 | :white_check_mark: | [upit](./upit)                                       | Very very simple library to initialise your app stack.              |                                |
 | :white_check_mark: | [zetasketch](./zetasketch)                           | Sketch data structures like HLL                                     | requires reflect-config.json   |
+| :white_check_mark: | [pg2-core](./pg2-core)                               | A Fast PostgreSQL Driver For Clojure                                |                                |
 
 
 More libraries to come (*PRs are welcome*).

--- a/pedestal/README.md
+++ b/pedestal/README.md
@@ -17,6 +17,8 @@ Test with:
 
 ## Results
 
+Pedestal don't work without `--initialize-at-build-time` but it does not conflict with the usage of `graal-build-time`.
+
 `[io.pedestal.http :as http]` :white_check_mark:
 `[io.pedestal.jetty :as jetty]` :white_check_mark:
 `[io.pedestal.http.body-params :as body-params]` :white_check_mark:

--- a/pedestal/README.md
+++ b/pedestal/README.md
@@ -20,6 +20,9 @@ Test with:
 Pedestal don't work without `--initialize-at-build-time` but it does not conflict with the usage of `graal-build-time`.
 
 `[io.pedestal.http :as http]` :white_check_mark:
+
 `[io.pedestal.jetty :as jetty]` :white_check_mark:
+
 `[io.pedestal.http.body-params :as body-params]` :white_check_mark:
+
 `[io.pedestal.interceptor :as pedestal.interceptor]` :white_check_mark:

--- a/pedestal/project.clj
+++ b/pedestal/project.clj
@@ -3,7 +3,8 @@
   :paths ["src"]
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [io.pedestal/pedestal.service "0.7.2"]
-                 [io.pedestal/pedestal.jetty "0.7.2"]]
+                 [io.pedestal/pedestal.jetty "0.7.2"]
+                 [com.github.clj-easy/graal-build-time "1.0.5"]]
 
   :main simple.main
 
@@ -22,6 +23,7 @@
     "--allow-incomplete-classpath"
     "--initialize-at-build-time"
     "--enable-url-protocols=http,https"
+    "--features=clj_easy.graal_build_time.InitClojureClasses"
     "-Dio.pedestal.log.defaultMetricsRecorder=nil"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
     "-H:ReflectionConfigurationFiles=reflect-config.json"

--- a/pg2-core/.gitignore
+++ b/pg2-core/.gitignore
@@ -1,0 +1,15 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+/pg2.iml
+/.idea/
+/pg2-core.iml

--- a/pg2-core/README.md
+++ b/pg2-core/README.md
@@ -1,0 +1,20 @@
+# PG2
+
+Testing whether [pg2](https://github.com/igrishaev/pg2) library can be used in a native binary image with GraalVM(23).
+
+## Usage
+
+Currently testing:
+
+    [com.github.igrishaev/pg2-core "0.1.19"]
+
+Test with (requires a local GraalVM installation):
+
+- You need to start the PostgreSQL container before executing the bynary result: `docker compose up -d`
+
+- Generating and executing the image: ```lein do clean, uberjar, native, run-native```
+
+## Results
+
+`[pg.core :as pg]` :white_check_mark:
+`[pg.pool :as pool]` :white_check_mark:

--- a/pg2-core/docker-compose.yml
+++ b/pg2-core/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    image: postgres
+    container_name: postgres
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres-db
+    ports:
+      - "5432:5432"

--- a/pg2-core/project.clj
+++ b/pg2-core/project.clj
@@ -1,0 +1,25 @@
+(defproject pg2-core "0.1.0-SNAPSHOT"
+
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [com.github.igrishaev/pg2-core "0.1.19"]
+                 [com.github.clj-easy/graal-build-time "1.0.5"]]
+
+  :main pg2-core.main
+
+  :uberjar-name "pg2-core.jar"
+
+  :profiles {:uberjar {:aot :all}
+             :dev     {:plugins [[lein-shell "0.5.0"]]}}
+
+  :aliases
+  {"native"
+   ["shell"
+    "native-image"
+    "--no-fallback"
+    "--allow-incomplete-classpath"
+    "--report-unsupported-elements-at-runtime"
+    "--features=clj_easy.graal_build_time.InitClojureClasses"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-H:Name=./target/${:name}"]
+
+   "run-native" ["shell" "./target/${:name}"]})

--- a/pg2-core/src/pg2_core/main.clj
+++ b/pg2-core/src/pg2_core/main.clj
@@ -1,0 +1,51 @@
+(ns pg2-core.main
+  (:gen-class)
+  (:require [pg.core :as pg]
+            [pg.pool :as pool]))
+
+(def config
+  {:host     "localhost"
+   :port     5432
+   :user     "postgres"
+   :password "password"
+   :database "postgres-db"})
+
+(defn create-connection [config]
+  (pg/connect config))
+
+(defn create-table! [conn]
+  (pg/execute conn "DROP TABLE IF EXISTS students")
+  (pg/execute conn "CREATE TABLE IF NOT EXISTS students (name VARCHAR(100) NOT NULL)"))
+
+(defn insert-student! [conn name]
+  (pg/execute conn
+              "INSERT INTO students (name) VALUES ($1)
+              returning *"
+              {:params [name]}))
+
+(defn lookup [conn name]
+  (pg/execute conn
+              "SELECT * FROM students WHERE name = $1"
+              {:params [name]}))
+
+(defn using-conn []
+  (println "----Using Connection----")
+  (println "PG2 Connection:" (create-connection config))
+  (let [conn (create-connection config)]
+    (println "Table creation:" (create-table! conn))
+    (println "Student 'Manuel Gomes' inserted:" (insert-student! conn "Manuel Gomes"))
+    (println "Query 'Manuel Gomes's Student entity:" (lookup conn "Manuel Gomes"))
+    (println "Connection closed:" (nil? (pg/close conn)))))
+
+(defn using-conn-from-poll []
+  (println "----Using Connection Poll----")
+  (pool/with-pool [pool config]
+    (pool/with-connection [conn pool]
+      (println "Table creation:" (create-table! conn))
+      (println "Student 'Manuel Gomes' inserted:" (insert-student! conn "Manuel Gomes"))
+      (println "Query 'Manuel Gomes's Student entity:" (lookup conn "Manuel Gomes")))))
+
+(defn -main []
+  (println "Hello GraalVM.")
+  (using-conn)
+  (using-conn-from-poll))


### PR DESCRIPTION
Adding PG2.

Pedestal don't work without `--initialize-at-build-time` so I was curious about the incompatibility with `graal-build-time`, but there was no observable incompatibility symptoms.