### PR TITLE
Add `next.jdbc` + `SQLite driver`

### DIFF
--- a/sqlite/.gitignore
+++ b/sqlite/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 /.idea/
 /sample-project.iml
 /sqlite.iml
+/.my-test.db

--- a/sqlite/.gitignore
+++ b/sqlite/.gitignore
@@ -1,0 +1,15 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+/.idea/
+/sample-project.iml
+/sqlite.iml

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -1,0 +1,24 @@
+# next.jdbc + SQLite Driver
+
+Testing
+whether [next.jdbc](https://github.com/seancorfield/next-jdbc) + [SQLite driver](https://github.com/xerial/sqlite-jdbc)
+can be used in a native binary image with GraalVM(23).
+
+## Usage
+
+Currently testing:
+
+    [org.xerial/sqlite-jdbc "3.41.2.1"]
+    [com.github.seancorfield/next.jdbc "1.3.955"]
+
+Test with (requires a local GraalVM installation):
+
+    lein do clean, uberjar, native, run-native
+
+## Results
+
+    [clojure.java.io :as io] :white_check_mark:
+
+    [next.jdbc :as jdbc] :white_check_mark:
+    
+    [next.jdbc.result-set :as rs] :white_check_mark:

--- a/sqlite/project.clj
+++ b/sqlite/project.clj
@@ -1,0 +1,29 @@
+(defproject sqlite "0.1.0-SNAPSHOT"
+
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [org.xerial/sqlite-jdbc "3.41.2.1"]
+                 [com.github.seancorfield/next.jdbc "1.3.955"]
+                 [com.github.clj-easy/graal-build-time "1.0.5"]]
+
+  :main sqlite.main
+
+  :uberjar-name "sqlite.jar"
+
+  :profiles {:uberjar {:aot :all}
+             :dev     {:plugins [[lein-shell "0.5.0"]]}}
+
+  :aliases
+  {"native"
+   ["shell"
+    "native-image"
+    "-Ob"
+    "-H:+TraceNativeToolUsage"
+    "-H:+AllowIncompleteClasspath"
+    "--verbose"
+    "--no-fallback"
+    "--report-unsupported-elements-at-runtime"
+    "--features=clj_easy.graal_build_time.InitClojureClasses"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-H:Name=./target/${:name}"]
+
+   "run-native" ["shell" "./target/${:name}"]})

--- a/sqlite/src/sqlite/main.clj
+++ b/sqlite/src/sqlite/main.clj
@@ -1,0 +1,40 @@
+(ns sqlite.main
+  (:gen-class)
+  (:require [clojure.java.io :as io]
+            [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as rs]))
+
+(defn make-spec []
+  (let [lsp-db (io/file ".my-test.db")]
+    {:dbtype "sqlite"
+     :dbname (.getAbsolutePath lsp-db)}))
+
+(defn insert []
+  (println "Inserting...")
+  (let [db-spec (make-spec)]
+    (io/make-parents (:dbname db-spec))
+    (with-open [conn (jdbc/get-connection db-spec)]
+      (jdbc/execute! conn ["drop table if exists project;"])
+      (jdbc/execute! conn ["create table project (version text, root text unique, hash text, classpath text, analysis text);"])
+      (jdbc/execute! conn ["insert or replace into project
+                            (version, root, hash, classpath, analysis)
+                            values (?,?,?,?,?);" "1" "some-project" "some-hash" "some-classpath" "a lot of analysis"]))))
+
+(defn select []
+  (println "Selecting...")
+  (try
+    (with-open [conn (jdbc/get-connection (make-spec))]
+      (let [project-row (-> (jdbc/execute! conn
+                                           ["select root, hash, classpath, analysis from project where version = ?"
+                                            "1"]
+                                           {:builder-fn rs/as-unqualified-lower-maps})
+                            (nth 0))]
+        (println "Success: " project-row)))
+    (catch Throwable e
+      (println "Could not load db" (.getMessage e)))))
+
+
+(defn -main []
+  (println "Hello GraalVM.")
+  (insert)
+  (select))


### PR DESCRIPTION
This pull request introduces a new project for testing the integration of `next.jdbc` with the SQLite driver in a native binary image using GraalVM.