### PR TITLE
Bump aws-api + s3 dependencies to their latest versions

### DIFF
--- a/aws-api-s3/.gitignore
+++ b/aws-api-s3/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/
+/aws-api-s3.iml

--- a/aws-api-s3/README.md
+++ b/aws-api-s3/README.md
@@ -6,9 +6,9 @@ Testing whether [cognitect/aws-api+s3](https://github.com/cognitect-labs/aws-api
 
 Currently testing:
 
-    [com.cognitect.aws/api       "0.8.301"]
-    [com.cognitect.aws/endpoints "1.1.11.537"]
-    [com.cognitect.aws/s3        "714.2.430.0"]
+    [com.cognitect.aws/api       "0.8.692"]
+    [com.cognitect.aws/endpoints "1.1.12.772"]
+    [com.cognitect.aws/s3        "869.2.1687.0"]
 
 Gotchas:
 

--- a/aws-api-s3/graalvm-resources/resource-config.json
+++ b/aws-api-s3/graalvm-resources/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "cognitect/aws/.+\\.edn"
+      },
+      {
+        "pattern" : "cognitect_aws_http.edn"
       }
     ]
   }

--- a/aws-api-s3/project.clj
+++ b/aws-api-s3/project.clj
@@ -1,30 +1,31 @@
 (defproject aws-api-s3 "0.1.0-SNAPSHOT"
 
-  :dependencies [[org.clojure/clojure         "1.10.2-rc1"]
-                 [com.cognitect.aws/api       "0.8.484"]
-                 [com.cognitect.aws/endpoints "1.1.11.926"]
-                 [com.cognitect.aws/s3        "810.2.817.0"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [com.cognitect.aws/api "0.8.692"]
+                 [com.cognitect.aws/endpoints "1.1.12.772"]
+                 [com.cognitect.aws/s3 "869.2.1687.0"]
+                 [com.github.clj-easy/graal-build-time "1.0.5"]]
 
   :main simple.main
 
   :uberjar-name "simple-main.jar"
   :profiles {:uberjar {:aot :all}
-             :dev {:plugins [[lein-shell "0.5.0"]]}}
+             :dev     {:plugins [[lein-shell "0.5.0"]]}}
 
   :aliases
-  {"native-config"
+  {"native"
    ["shell"
-    ;; run the application to infer the build configuration
-    "java" "-agentlib:native-image-agent=config-output-dir=./target/config/"
-    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"]
-
-   "native"
-   ["shell"
-    "native-image" "--report-unsupported-elements-at-runtime" "--no-server" "--no-fallback"
-    "-H:+PrintClassInitialization"
-    "-H:ConfigurationFileDirectories=./target/config/"
-    "--initialize-at-build-time"
+    "native-image"
+    "--no-fallback"
+    "--report-unsupported-elements-at-runtime"
+    "--no-server"
     "--allow-incomplete-classpath"
+    "--initialize-at-build-time"
+    "-H:+PrintClassInitialization"
+    "--features=clj_easy.graal_build_time.InitClojureClasses"
+
+    "-H:IncludeResources='.*/service.*edn'"
+
     "--enable-http" "--enable-https" "--enable-all-security-services"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
     "-H:Name=./target/${:name}"]

--- a/aws-api-s3/project.clj
+++ b/aws-api-s3/project.clj
@@ -24,7 +24,8 @@
     "-H:+PrintClassInitialization"
     "--features=clj_easy.graal_build_time.InitClojureClasses"
 
-    "-H:IncludeResources='.*/service.*edn'"
+    "-H:+UnlockExperimentalVMOptions"
+    "-H:ConfigurationFileDirectories=resources"
 
     "--enable-http" "--enable-https" "--enable-all-security-services"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"

--- a/aws-api-s3/project.clj
+++ b/aws-api-s3/project.clj
@@ -25,7 +25,7 @@
     "--features=clj_easy.graal_build_time.InitClojureClasses"
 
     "-H:+UnlockExperimentalVMOptions"
-    "-H:ConfigurationFileDirectories=resources"
+    "-H:ConfigurationFileDirectories=graalvm-resources"
 
     "--enable-http" "--enable-https" "--enable-all-security-services"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"

--- a/aws-api-s3/resources/config.edn
+++ b/aws-api-s3/resources/config.edn
@@ -1,0 +1,2 @@
+{:access-key-id     "RANDOM-ACCESS-KEY-ID"
+ :secret-access-key "random/secret/access-key"}

--- a/aws-api-s3/resources/resource-config.json
+++ b/aws-api-s3/resources/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "cognitect/aws/.+\\.edn"
+      }
+    ]
+  }
+}

--- a/aws-api-s3/src/simple/main.clj
+++ b/aws-api-s3/src/simple/main.clj
@@ -4,7 +4,6 @@
             ;; there are dynamically loaded at runtime
             [cognitect.aws.http.cognitect]
             [cognitect.aws.protocols.json]
-            [cognitect.aws.protocols.common]
             [cognitect.aws.protocols.rest]
             [cognitect.aws.protocols.rest-xml]
             [clojure.spec.alpha])


### PR DESCRIPTION
Applied `com.github.clj-easy/graal-build-time`.

Bumped dependencies to their latest versions:
```clojure
  [org.clojure/clojure "1.12.0"]
  [com.cognitect.aws/api "0.8.692"]
  [com.cognitect.aws/endpoints "1.1.12.772"]
  [com.cognitect.aws/s3 "869.2.1687.0"]
```